### PR TITLE
Use linux as GOOS. Add linux64 task

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,11 @@
 VERSION := $(shell git describe --tags)
 
-linux:
-	GOOS=darwin GOARCH=386 go build -o ./dist/mgphoto-linux -ldflags="-X main.version=${VERSION}" ./*.go
+linux32:
+	GOOS=linux GOARCH=386 go build -o ./dist/mgphoto-linux -ldflags="-X main.version=${VERSION}" ./*.go
 
+linux64:
+	GOOS=linux GOARCH=amd64 go build -o ./dist/mgphoto-linux -ldflags="-X main.version=${VERSION}" ./*.go
+	
 mac:
 	GOOS=darwin GOARCH=amd64 go build -o ./dist/mgphoto-mac -ldflags="-X main.version=${VERSION}" ./*.go
 	

--- a/makefile
+++ b/makefile
@@ -15,4 +15,4 @@ windows:
 clean:
 	rm -rf ./dist
 
-all: linux mac windows
+all: linux32 linux64 mac windows


### PR DESCRIPTION
Linux builds fail to run due to wrong GOOS value